### PR TITLE
Changes to makeCall (problem 2)

### DIFF
--- a/closures.js
+++ b/closures.js
@@ -34,17 +34,17 @@ another variable called 'inner'. */
 \******************************************************************************/
 
 
-var callFriend = function(){
-  var friend = 'Jake';
-  function callF(number){
-    return 'Calling ' + friend + ' at ' + number;
+var callFriend = function(name) {
+  var friend = name
+  function dial(number) {
+    return 'Calling ' + friend + ' at ' + number
   }
-  return callF;
-};
+  return dial
+}
 
 /****** INSTRUCTIONS PROBLEM 2 ******/
-/* Above you're given a callFriend function that returns another function.
-Create a makeCall function that when invoked logs 'Calling Jake at 435-215-9248'
+/* Above you're given a callFriend function that returns the dial function.
+Create a callJake function that when invoked logs 'Calling Jake at 435-555-9248'
 in your console. */
 
   //Code Here

--- a/closures.js
+++ b/closures.js
@@ -44,11 +44,10 @@ var callFriend = function(name) {
 
 /****** INSTRUCTIONS PROBLEM 2 ******/
 /* Above you're given a callFriend function that returns the dial function.
-Create a callJake function that when invoked logs 'Calling Jake at 435-555-9248'
+Create a callJake function that when invoked with '435-555-9248' returns 'Calling Jake at 435-555-9248'
 in your console. */
 
   //Code Here
-
 
 
 

--- a/test/spec/ClosuresSpec.js
+++ b/test/spec/ClosuresSpec.js
@@ -12,20 +12,21 @@ describe('closures', function () {
 		})
 	})
 
-	describe('makeCall', function () {
+	describe('callJake', function () {
 		it('should exist', function () {
-			expect(makeCall).toBeDefined();
+			expect(callJake).toBeDefined();
 		})
 		it('should be a function', function () {
-			expect(makeCall).toEqual(jasmine.any(Function));
+			expect(callJake).toEqual(jasmine.any(Function));
 		})
-		it('should be the callFriend function', function () {
-			expect(JSON.stringify(makeCall)).toEqual(JSON.stringify(callFriend()));
+		it('should return Calling Jake at 435-215-9248', function () {
+			expect( callJake('435-215-9248')).toBe('Calling Jake at 435-215-9248');        
 		})
-		//it('should return Calling Jake at 435-215-9248', function () {
-		//	expect( makeCall('435-215-9248')).toBe('Calling Jake at 435-215-9248');
-        //
-		//})
+		it('should use the dial function', function () {
+			var newCall = callFriend('Jake');
+			expect(newCall('1')).toEqual(callJake('1'));
+		})
+
 	})
 
 
@@ -131,9 +132,7 @@ describe('timeOutCounter', function() {
 		expect(timeOutCounter).toEqual(jasmine.any(Function))
 	})
 
-
-	it('should call setTimeout 5 times', function() {
-
+	it('should call setTimeout 6 times', function() {
 		timeOutCounter();
 
 		jasmine.clock().tick(500);


### PR DESCRIPTION
Previously, the tests for makeCall were only testing that the function existed. The comparison between the user's function and the inner function were relying on JSON.stringify, which was returning undefined for both cases, so I switched to comparing their outputs. At Dallin's recommendation, I also changed the entire problem to make it clearer.